### PR TITLE
Add reference to source of angular bloodhound port

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ mytemplate.html:
 
 ## Details
 
-`ngAtp` implements Twitter `Bloodhound` as a `Angular` service, `ngBloodhound` uses `Angular`'s `$http` service as opposed to `jQuery` `$.ajax` in the original version. Other than that, suggestions are entirely managed by `Bloodhound` with all its prefetching, intelligent caching, fast lookups, and backfilling. On the rendering/directive side of things, `ngAtp` relies on `ng-model` and `ng-repeat` (without filtering, which is handled by `Bloodhound`), and tries to stick to default Angular directives as
+`ngAtp` implements Twitter `Bloodhound` as a `Angular` service, `ngBloodhound` uses `Angular`'s `$http` service as opposed to `jQuery` `$.ajax` in the original version (inspired by [twhitbeck/angular-bloodhound](https://www.github.com/twhitbeck/angular-bloodhound)). Other than that, suggestions are entirely managed by `Bloodhound` with all its prefetching, intelligent caching, fast lookups, and backfilling. On the rendering/directive side of things, `ngAtp` relies on `ng-model` and `ng-repeat` (without filtering, which is handled by `Bloodhound`), and tries to stick to default Angular directives as
 much as possilbe. 
 
 


### PR DESCRIPTION
I use the term "inspired" loosely. I should also mention that when I created angular-bloodhound, I started with typeahead v0.10.2 with my own custom fix for an issue that existed in official Bloodhound. That issue was fixed with typeahead.js v0.10.3.
Unless you intend to merge updates from typeahead.js bloodhound to this angularized copy, you should make your users aware that they won't be getting the benefits of @jharding's continued work on typeahead.js/bloodhound
