### PR TITLE
fix typo in docs, from templateUrl to template-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ Added in config options: `completeOn`. Default Value : `{ tab: true, rightArrow:
 Set `ng-atp` attribute value to the variable in scope you'd like to autocomplete for, same way you'd use a `ngModel` directive. Pass [`Bloodhound`](https://github.com/twitter/typeahead.js/blob/master/doc/bloodhound.md) config object using `ng-atp-config` attribute. Additonal config options: `idAttribute`, specify the key/id attribute to use for tracking suggestion items (similar to `track by` for ng-repeat). Also, you should to supply two functions in config: `format` and `verify`(optional). `format` is expected to be a function that takes a suggestion datum (eg. `{ label: "Thing", id: 1}`) into a string to display, and `verify` is expected to be a function that takes a single suggestion datum as an argument, and returns a boolean (be sure to return false for null). 
 
 
-In addition, `ng-atp-suggestions` allows you to use custom template by suppling an attribute `templateUrl`. `templateUrl` should point to a valid `Angular` template for a single suggestion item (which will be wrapped inside a `<li>` tag), and `ng-atp-suggestions` expose the scope variable `suggestion` for your template, as well as setting the class of the corresponding item to "selected" from user interactions (hover, and arrow key press). An example template may look like this:
+In addition, `ng-atp-suggestions` allows you to use custom template by suppling an attribute `template-url`. `template-url` should point to a valid `Angular` template for a single suggestion item (which will be wrapped inside a `<li>` tag), and `ng-atp-suggestions` expose the scope variable `suggestion` for your template, as well as setting the class of the corresponding item to "selected" from user interactions (hover, and arrow key press). An example template may look like this:
 
 ```
-<ul ng-atp-suggestions templateUrl="partials/mytemplate.html">
+<ul ng-atp-suggestions template-url="partials/mytemplate.html">
 ```
 
 


### PR DESCRIPTION
Hi !

First and foremost, thanks a lot for putting all this work into this great directive (both performant and easy to use, all I like). 
I just ran into an issue with the custom template attribute, scratched my head a little bit and found out that if you put `templateUrl` in your directive, it is interpreted as `templateurl`, not taken into account and thus the default template always appears.

Anyways, I just thought it might be useful to fix the docs :)

Cheers
