### PR TITLE
add single quotes to the template-url value

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Set `ng-atp` attribute value to the variable in scope you'd like to autocomplete
 In addition, `ng-atp-suggestions` allows you to use custom template by suppling an attribute `templateUrl`. `templateUrl` should point to a valid `Angular` template for a single suggestion item (which will be wrapped inside a `<li>` tag), and `ng-atp-suggestions` expose the scope variable `suggestion` for your template, as well as setting the class of the corresponding item to "selected" from user interactions (hover, and arrow key press). An example template may look like this:
 
 ```
-<ul ng-atp-suggestions templateUrl="partials/mytemplate.html">
+<ul ng-atp-suggestions templateUrl="'partials/mytemplate.html'">
 ```
 
 


### PR DESCRIPTION
Hi again !

Another one : I needed to explicitly pass a string to the template-url attribute in order for the directive to pick-up my template. If no extra quotes are given, it just spits a NaN and nothing is rendered.

I guess such a behaviour is implied but I updated the docs to make it more explicit.

Cheers